### PR TITLE
Handle sourcemaps when concatenating files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.4.0
+
+* Handle sourcemaps
+
 ## 0.3.0
 
 * Update to 0.6.x API

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var gobble = require( 'gobble' );
 module.exports = gobble( 'js' ).transform( 'concat', { dest: 'bundle.js' });
 ```
 
-The `dest` property is required. Other values - `files`, `sort` and `separator`, explained below - are optional.
+The `dest` property is required. Other values - `files`, `sort`, `separator` and `writeSourcemap`, explained below - are optional.
 
 ### `files`
 
@@ -64,7 +64,22 @@ module.exports = gobble( 'js' )
   });
 ```
 
+### `writeSourcemap`
+
+Concatenating javascript or CSS files requires some extra handling of their sourcemaps, specially in complex workflows. With this option set to `true`, the sourcemaps of the files to be concatenated will be parsed, files with no sourcemap will be assigned an identity (1:1) sourcemap, and a new sourcemap will be generated from all of them.
+
+The default value is `true` when `dest` is a file with a `.js` or `.css` extension, and `false` otherwise.
+
 
 ## License
 
 MIT. Copyright 2014 Rich Harris
+
+---
+
+"THE BEER-WARE LICENSE":
+<ivan@sanchezortega.es> wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think
+this stuff is worth it, you can buy me a beer in return.
+
+---

--- a/index.js
+++ b/index.js
@@ -1,16 +1,27 @@
+var sander = require( 'sander' ),
+    path = require( 'path' ),
+    mapSeries = require( 'promise-map-series' ),
+    minimatch = require( 'minimatch' );
+var SourceNode = require( 'source-map' ).SourceNode;
+var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
+
+var sourceMapRegExp = new RegExp(/(?:\/\/#|\/\/@|\/\*#)\s*sourceMappingURL=(.*)\s*(?:\*\/\s*)?$/);
+var extensionsRegExp = new RegExp(/(\.js|\.css)$/);
+
 module.exports = function concat ( inputdir, outputdir, options ) {
-	var sander = require( 'sander' );
 
 	if ( !options.dest ) {
 		throw new Error( 'You must pass a \'dest\' option to gobble-concat' );
 	}
 
+	if ( options.writeSourcemap === undefined ) {
+		options.writeSourcemap = !!options.dest.match( extensionsRegExp );
+	}
+
 	return sander.lsr( inputdir ).then( function ( allFiles ) {
-		var mapSeries = require( 'promise-map-series' ),
-			minimatch = require( 'minimatch' ),
-			patterns = options.files,
+		var patterns = options.files,
 			alreadySeen = {},
-			fileContents = [];
+			nodes = [];
 
 		if ( !patterns ) {
 			// use all files
@@ -35,16 +46,63 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 			return processFiles( filtered.sort( options.sort ) );
 		}).then( writeResult );
 
+
 		function processFiles ( filenames ) {
 			return mapSeries( filenames.sort( options.sort ), function ( filename ) {
-				return sander.readFile( inputdir, filename ).then( function ( contents ) {
-					fileContents.push( contents.toString() );
+				return sander.readFile( inputdir, filename ).then( function ( fileContents ) {
+
+					/// Run a regexp against the code to check for source mappings.
+					var match = sourceMapRegExp.exec(fileContents);
+
+					if (!match) {
+// 						if (options.verbose)	console.log('Creating ident sourcemap for ', filename);
+						var newNode = new SourceNode(1, 1, filename, fileContents.toString());
+						newNode.setSourceContent(filename, fileContents.toString());
+						nodes.push( newNode );
+					} else {
+						var sourcemapFilename = match[1];
+
+						return sander.readFile( inputdir, path.dirname(filename), sourcemapFilename ).then( function ( mapContents ) {
+							// Sourcemap exists
+							var parsedMap = new SourceMapConsumer( mapContents.toString() );
+							nodes.push( SourceNode.fromStringWithSourceMap( fileContents.toString(), parsedMap ) );
+// 							if (options.verbose) console.log('Loaded sourcemap for ', filename + ': ' + sourcemapFilename + "(" + mapContents.length + " bytes)");
+						}, function(err) {
+							throw new Error('File ' + inputdir + ' / ' + filename + ' refers to a non-existing sourcemap at ' + sourcemapFilename + ' ' + err);
+						});
+					}
 				});
 			});
 		}
 
 		function writeResult () {
-			return sander.writeFile( outputdir, options.dest, fileContents.join( options.separator || '\n\n' ) );
+			if (!nodes[0]) {
+				// Degenerate case: no matched files
+				return sander.writeFile( outputdir, options.dest, '' );
+			}
+
+			var separatorNode = new SourceNode(null, null, null, options.separator || '\n\n');
+
+			var dest = new SourceNode(null, null, null, '');
+			dest.add(nodes[0]);
+
+			for (var i=1; i<nodes.length; i++) {
+				dest.add(separatorNode);
+				dest.add(nodes[i]);
+			}
+			var generated = dest.toStringWithSourceMap();
+
+			if ( options.writeSourcemap ) {
+				var sourceMapLocation = '\n\n//# sourceMappingURL=' + path.join(outputdir, options.dest + '.map') + '\n'
+
+				return sander.Promise.all([
+					sander.writeFile( outputdir, options.dest, generated.code + sourceMapLocation ),
+					sander.writeFile( outputdir, options.dest + '.map', generated.map.toString() )
+				]);
+			} else {
+				return sander.writeFile( outputdir, options.dest, generated.code);
+			}
+
 		}
 	});
 };

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "gobble-concat",
   "description": "Concatenate files with gobble",
-  "version": "0.3.0",
-  "author": "Rich Harris",
+  "version": "0.4.0",
+  "authors": [
+    "Rich Harris",
+    "Iván Sánchez Ortega <ivan@sanchezortega.es>"
+  ],
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-concat",
   "files": [
@@ -14,6 +17,7 @@
   "dependencies": {
     "minimatch": "~1.0.0",
     "promise-map-series": "~0.2.0",
-    "sander": "^0.1.6"
+    "sander": "^0.1.6",
+    "source-map": "^0.5.3"
   }
 }


### PR DESCRIPTION
When I concatenate files in some of my workflows, sourcemaps are lost in the way, and/or files without sourcemaps are merged silently into the result of the concatenation.

I managed to fix this issue by managing sourcemaps manually in `gobble-concat` (parsing, creating and merging them as needed). The results are good IMHO.

I thought about creating something like `gobble-bundle`, but I feel it's better to push this into the main source tree.
