### PR TITLE
Use `/*# */` comments in CSS files (instead of `//#`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.4.2
+
+* Fixed ident sourcemap generation (for files without one)
+
 ## 0.4.1
 
 * Use `/*# */` comments in CSS files (instead of `//#`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.4.1
+
+* Use `/*# */` comments in CSS files (instead of `//#`)
+
 ## 0.4.0
 
 * Handle sourcemaps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.4.3
+
+* Fixed extra newlines on ident sourcemap generation
+
 ## 0.4.2
 
 * Fixed ident sourcemap generation (for files without one)

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var sander = require( 'sander' ),
 var SourceNode = require( 'source-map' ).SourceNode;
 var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
 
-var sourceMapRegExp = new RegExp(/(?:\/\/#|\/\/@|\/\*#)\s*sourceMappingURL=(.*)\s*(?:\*\/\s*)?$/);
+var sourceMapRegExp = new RegExp(/(?:\/\/#|\/\/@|\/\*#)\s*sourceMappingURL=(\S*)\s*(?:\*\/\s*)?$/);
 var extensionsRegExp = new RegExp(/(\.js|\.css)$/);
 
 module.exports = function concat ( inputdir, outputdir, options ) {
@@ -93,7 +93,12 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 			var generated = dest.toStringWithSourceMap();
 
 			if ( options.writeSourcemap ) {
-				var sourceMapLocation = '\n\n//# sourceMappingURL=' + path.join(outputdir, options.dest + '.map') + '\n'
+				var sourceMapLocation;
+				if (options.dest.match(/\.css$/)) {
+					sourceMapLocation = '\n\n/*# sourceMappingURL=' + path.join(outputdir, options.dest + '.map') + ' */\n';
+				} else {
+					sourceMapLocation = '\n\n//# sourceMappingURL=' + path.join(outputdir, options.dest + '.map') + '\n'
+				}
 
 				return sander.Promise.all([
 					sander.writeFile( outputdir, options.dest, generated.code + sourceMapLocation ),

--- a/index.js
+++ b/index.js
@@ -59,11 +59,17 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 // 						if (options.verbose)	console.log('Creating ident sourcemap for ', filename);
 						var lines = fileContents.split('\n');
 						var lineCount = lines.length;
+						var identNode = new SourceNode(null, null, null, '');
+						var newLineNode = new SourceNode(null, null, null, '\n');
+
+						identNode.setSourceContent(filename, fileContents);
+
 						for (var i=0; i<lineCount; i++) {
-							var newNode = new SourceNode(i+1, 1, filename, lines[i]);
-							newNode.setSourceContent(filename, fileContents);
-							nodes.push( newNode );
+							var lineNode = new SourceNode(i+1, 1, filename, lines[i]);
+							if (i) { identNode.add(newLineNode); }
+							identNode.add(lineNode);
 						}
+						nodes.push( identNode );
 					} else {
 						var sourcemapFilename = match[1];
 

--- a/index.js
+++ b/index.js
@@ -53,19 +53,24 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 
 					/// Run a regexp against the code to check for source mappings.
 					var match = sourceMapRegExp.exec(fileContents);
+					fileContents = fileContents.toString();
 
 					if (!match) {
 // 						if (options.verbose)	console.log('Creating ident sourcemap for ', filename);
-						var newNode = new SourceNode(1, 1, filename, fileContents.toString());
-						newNode.setSourceContent(filename, fileContents.toString());
-						nodes.push( newNode );
+						var lines = fileContents.split('\n');
+						var lineCount = lines.length;
+						for (var i=0; i<lineCount; i++) {
+							var newNode = new SourceNode(i+1, 1, filename, lines[i]);
+							newNode.setSourceContent(filename, fileContents);
+							nodes.push( newNode );
+						}
 					} else {
 						var sourcemapFilename = match[1];
 
 						return sander.readFile( inputdir, path.dirname(filename), sourcemapFilename ).then( function ( mapContents ) {
 							// Sourcemap exists
 							var parsedMap = new SourceMapConsumer( mapContents.toString() );
-							nodes.push( SourceNode.fromStringWithSourceMap( fileContents.toString(), parsedMap ) );
+							nodes.push( SourceNode.fromStringWithSourceMap( fileContents, parsedMap ) );
 // 							if (options.verbose) console.log('Loaded sourcemap for ', filename + ': ' + sourcemapFilename + "(" + mapContents.length + " bytes)");
 						}, function(err) {
 							throw new Error('File ' + inputdir + ' / ' + filename + ' refers to a non-existing sourcemap at ' + sourcemapFilename + ' ' + err);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobble-concat",
   "description": "Concatenate files with gobble",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "authors": [
     "Rich Harris",
     "Iván Sánchez Ortega <ivan@sanchezortega.es>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobble-concat",
   "description": "Concatenate files with gobble",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "authors": [
     "Rich Harris",
     "Iván Sánchez Ortega <ivan@sanchezortega.es>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobble-concat",
   "description": "Concatenate files with gobble",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "authors": [
     "Rich Harris",
     "Iván Sánchez Ortega <ivan@sanchezortega.es>"


### PR DESCRIPTION
In `0.4.0`, I used `//#`-style comments for all `sourceURL`s. This works fine when gobble-concat is the last step (browsers accept that input), but if there is another transform after concat (in my case, I discovered the bug with gobble-autoprefixer), the build might fail.

Unfortunately this creates a different problem with <s>gobble's auto-detection of CSS sourcemaps somewhere</s> `gobble-autoprefixer` and its buggy way of doing sourcemaps.
