### PR TITLE
-> 0.5: Only create sourcemaps for concatenation, add tests, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules
 test/tests/*/output
+index.js
+!src/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+test/tests/*/output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # changelog
 
+## 0.5.0
+
+* Ignore input sourcemaps
+
+## 0.4.0
+
+* Handle sourcemaps
+
 ## 0.3.0
 
 * Update to 0.6.x API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # changelog
 
-## 0.4.0
-
-* Handle sourcemaps
-
 ## 0.3.0
 
 * Update to 0.6.x API

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var gobble = require( 'gobble' );
 module.exports = gobble( 'js' ).transform( 'concat', { dest: 'bundle.js' });
 ```
 
-The `dest` property is required. Other values - `files`, `sort`, `separator` and `writeSourcemap`, explained below - are optional.
+The `dest` property is required. Other values - `files`, `sort` and `separator`, explained below - are optional.
 
 ### `files`
 
@@ -64,22 +64,7 @@ module.exports = gobble( 'js' )
   });
 ```
 
-### `writeSourcemap`
-
-Concatenating javascript or CSS files requires some extra handling of their sourcemaps, specially in complex workflows. With this option set to `true`, the sourcemaps of the files to be concatenated will be parsed, files with no sourcemap will be assigned an identity (1:1) sourcemap, and a new sourcemap will be generated from all of them.
-
-The default value is `true` when `dest` is a file with a `.js` or `.css` extension, and `false` otherwise.
-
 
 ## License
 
 MIT. Copyright 2014 Rich Harris
-
----
-
-"THE BEER-WARE LICENSE":
-<ivan@sanchezortega.es> wrote this file. As long as you retain this notice you
-can do whatever you want with this stuff. If we meet some day, and you think
-this stuff is worth it, you can buy me a beer in return.
-
----

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ module.exports = gobble( 'js' )
 ## License
 
 MIT. Copyright 2014 Rich Harris
+
+---
+
+"THE BEER-WARE LICENSE":
+<ivan@sanchezortega.es> wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think
+this stuff is worth it, you can buy me a beer in return.
+
+---

--- a/index.js
+++ b/index.js
@@ -1,27 +1,16 @@
-var sander = require( 'sander' ),
-    path = require( 'path' ),
-    mapSeries = require( 'promise-map-series' ),
-    minimatch = require( 'minimatch' );
-var SourceNode = require( 'source-map' ).SourceNode;
-var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
-
-var sourceMapRegExp = new RegExp(/(?:\/\/#|\/\/@|\/\*#)\s*sourceMappingURL=(.*)\s*(?:\*\/\s*)?$/);
-var extensionsRegExp = new RegExp(/(\.js|\.css)$/);
-
 module.exports = function concat ( inputdir, outputdir, options ) {
+	var sander = require( 'sander' );
 
 	if ( !options.dest ) {
 		throw new Error( 'You must pass a \'dest\' option to gobble-concat' );
 	}
 
-	if ( options.writeSourcemap === undefined ) {
-		options.writeSourcemap = !!options.dest.match( extensionsRegExp );
-	}
-
 	return sander.lsr( inputdir ).then( function ( allFiles ) {
-		var patterns = options.files,
+		var mapSeries = require( 'promise-map-series' ),
+			minimatch = require( 'minimatch' ),
+			patterns = options.files,
 			alreadySeen = {},
-			nodes = [];
+			fileContents = [];
 
 		if ( !patterns ) {
 			// use all files
@@ -46,63 +35,16 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 			return processFiles( filtered.sort( options.sort ) );
 		}).then( writeResult );
 
-
 		function processFiles ( filenames ) {
 			return mapSeries( filenames.sort( options.sort ), function ( filename ) {
-				return sander.readFile( inputdir, filename ).then( function ( fileContents ) {
-
-					/// Run a regexp against the code to check for source mappings.
-					var match = sourceMapRegExp.exec(fileContents);
-
-					if (!match) {
-// 						if (options.verbose)	console.log('Creating ident sourcemap for ', filename);
-						var newNode = new SourceNode(1, 1, filename, fileContents.toString());
-						newNode.setSourceContent(filename, fileContents.toString());
-						nodes.push( newNode );
-					} else {
-						var sourcemapFilename = match[1];
-
-						return sander.readFile( inputdir, path.dirname(filename), sourcemapFilename ).then( function ( mapContents ) {
-							// Sourcemap exists
-							var parsedMap = new SourceMapConsumer( mapContents.toString() );
-							nodes.push( SourceNode.fromStringWithSourceMap( fileContents.toString(), parsedMap ) );
-// 							if (options.verbose) console.log('Loaded sourcemap for ', filename + ': ' + sourcemapFilename + "(" + mapContents.length + " bytes)");
-						}, function(err) {
-							throw new Error('File ' + inputdir + ' / ' + filename + ' refers to a non-existing sourcemap at ' + sourcemapFilename + ' ' + err);
-						});
-					}
+				return sander.readFile( inputdir, filename ).then( function ( contents ) {
+					fileContents.push( contents.toString() );
 				});
 			});
 		}
 
 		function writeResult () {
-			if (!nodes[0]) {
-				// Degenerate case: no matched files
-				return sander.writeFile( outputdir, options.dest, '' );
-			}
-
-			var separatorNode = new SourceNode(null, null, null, options.separator || '\n\n');
-
-			var dest = new SourceNode(null, null, null, '');
-			dest.add(nodes[0]);
-
-			for (var i=1; i<nodes.length; i++) {
-				dest.add(separatorNode);
-				dest.add(nodes[i]);
-			}
-			var generated = dest.toStringWithSourceMap();
-
-			if ( options.writeSourcemap ) {
-				var sourceMapLocation = '\n\n//# sourceMappingURL=' + path.join(outputdir, options.dest + '.map') + '\n'
-
-				return sander.Promise.all([
-					sander.writeFile( outputdir, options.dest, generated.code + sourceMapLocation ),
-					sander.writeFile( outputdir, options.dest + '.map', generated.map.toString() )
-				]);
-			} else {
-				return sander.writeFile( outputdir, options.dest, generated.code);
-			}
-
+			return sander.writeFile( outputdir, options.dest, fileContents.join( options.separator || '\n\n' ) );
 		}
 	});
 };

--- a/index.js
+++ b/index.js
@@ -23,15 +23,13 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 		var alreadySeen = {};
 		var fileContents = [];
 
-		if ( shouldCreateSourcemap ) {
-			var sourceMap = {
-				version: 3,
-				file: basename( options.dest ),
-				sources: [],
-				sourcesContent: [],
-				mappings: ''
-			};
-		}
+		var sourceMap = shouldCreateSourcemap ? {
+			version: 3,
+			file: basename( options.dest ),
+			sources: [],
+			sourcesContent: [],
+			mappings: ''
+		} : null;
 
 		if ( !patterns ) {
 			// use all files
@@ -66,6 +64,7 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 						sourceMap.sources.push( join( inputdir, filename ) );
 						sourceMap.sourcesContent.push( contents );
 
+						contents = contents.replace( /^(?:\/\/[@#]\s*sourceMappingURL=(\S+)|\/\*#?\s*sourceMappingURL=(\S+)\s?\*\/)$/gm, '' );
 						var lines = contents.split( '\n' );
 
 						var encoded = lines
@@ -104,7 +103,7 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 		}
 
 		function writeResult () {
-			var code = fileContents.join( options.separator || '\n\n' );
+			var code = fileContents.join( separator );
 
 			if ( shouldCreateSourcemap ) {
 				var comment = getSourcemapComment[ ext ]( basename( options.dest ) );

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "gobble-concat",
   "description": "Concatenate files with gobble",
-  "version": "0.3.0",
-  "author": "Rich Harris",
+  "version": "0.5.0",
+  "authors": [
+    "Rich Harris",
+    "Iván Sánchez Ortega <ivan@sanchezortega.es>"
+  ],
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-concat",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Rich Harris",
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-concat",
+  "scripts": {
+    "test": "mocha --compilers js:buble/register"
+  },
   "files": [
     "index.js"
   ],
@@ -14,6 +17,12 @@
   "dependencies": {
     "minimatch": "~1.0.0",
     "promise-map-series": "~0.2.0",
+    "sander": "^0.1.6"
+  },
+  "devDependencies": {
+    "buble": "^0.6.2",
+    "glob": "^7.0.3",
+    "mocha": "^2.4.5",
     "sander": "^0.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-concat",
   "scripts": {
-    "test": "mocha --compilers js:buble/register"
+    "test": "mocha --compilers js:buble/register",
+    "build": "buble -i src/index.js -o index.js --target node:0.10",
+    "pretest": "npm run build"
   },
   "files": [
     "index.js"
@@ -17,7 +19,8 @@
   "dependencies": {
     "minimatch": "~1.0.0",
     "promise-map-series": "~0.2.0",
-    "sander": "^0.1.6"
+    "sander": "^0.1.6",
+    "vlq": "^0.2.1"
   },
   "devDependencies": {
     "buble": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "gobble-concat",
   "description": "Concatenate files with gobble",
-  "version": "0.4.0",
-  "authors": [
-    "Rich Harris",
-    "Iván Sánchez Ortega <ivan@sanchezortega.es>"
-  ],
+  "version": "0.3.0",
+  "author": "Rich Harris",
   "license": "MIT",
   "repository": "https://github.com/gobblejs/gobble-concat",
   "files": [
@@ -17,7 +14,6 @@
   "dependencies": {
     "minimatch": "~1.0.0",
     "promise-map-series": "~0.2.0",
-    "sander": "^0.1.6",
-    "source-map": "^0.5.3"
+    "sander": "^0.1.6"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,24 @@
-var ref = require( 'path' ), basename = ref.basename, extname = ref.extname, join = ref.join;
-var sander = require( 'sander' );
-var mapSeries = require( 'promise-map-series' );
-var minimatch = require( 'minimatch' );
-var ref$1 = require( 'vlq' ), encode = ref$1.encode;
+const { basename, extname, join } = require( 'path' );
+const sander = require( 'sander' );
+const mapSeries = require( 'promise-map-series' );
+const minimatch = require( 'minimatch' );
+const { encode } = require( 'vlq' );
 
-var getSourcemapComment = {
-	'.js': function ( file ) { return ("//# sourceMappingURL=" + file + ".map"); },
-	'.css': function ( file ) { return ("/*# sourceMappingURL=" + file + ".map */"); }
+const getSourcemapComment = {
+	'.js': file => `//# sourceMappingURL=${file}.map`,
+	'.css': file => `/*# sourceMappingURL=${file}.map */`
 };
 
 module.exports = function concat ( inputdir, outputdir, options ) {
-	if ( !options.dest ) throw new Error( ("You must pass a 'dest' option to gobble-concat") );
+	if ( !options.dest ) throw new Error( `You must pass a 'dest' option to gobble-concat` );
 
-	var ext = extname( options.dest );
+	const ext = extname( options.dest );
 
-	var shouldCreateSourcemap = ( ext in getSourcemapComment ) && options.sourceMap !== false;
-	var separator = options.separator || '\n\n';
-	var separatorSemis = separator.split( '\n' ).join( ';' )
+	const shouldCreateSourcemap = ( ext in getSourcemapComment ) && options.sourceMap !== false;
+	const separator = options.separator || '\n\n';
+	const separatorSemis = separator.split( '\n' ).join( ';' )
 
-	return sander.lsr( inputdir ).then( function ( allFiles ) {
+	return sander.lsr( inputdir ).then( allFiles => {
 		var patterns = options.files;
 		var alreadySeen = {};
 		var fileContents = [];
@@ -54,28 +54,28 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 		}).then( writeResult );
 
 		function processFiles ( filenames ) {
-			var sourceIndexOffset = 0;
-			var sourceLineOffset = 0;
-			var sourceColumnOffset = 0;
+			let sourceIndexOffset = 0;
+			let sourceLineOffset = 0;
+			let sourceColumnOffset = 0;
 
-			var lineCount = 0;
+			let lineCount = 0;
 
-			return mapSeries( filenames.sort( options.sort ), function ( filename ) {
-				return sander.readFile( inputdir, filename, { encoding: 'utf-8' }).then( function ( contents ) {
+			return mapSeries( filenames.sort( options.sort ), filename => {
+				return sander.readFile( inputdir, filename, { encoding: 'utf-8' }).then( contents => {
 					if ( sourceMap ) {
 						sourceMap.sources.push( join( inputdir, filename ) );
 						sourceMap.sourcesContent.push( contents );
 
-						var lines = contents.split( '\n' );
+						const lines = contents.split( '\n' );
 
-						var encoded = lines
-							.map( function ( line ) {
-								var encodedLine = '';
+						const encoded = lines
+							.map( line => {
+								let encodedLine = '';
 
 								if ( line.length ) {
 									encodedLine += encode([ 0, sourceIndexOffset, sourceLineOffset, sourceColumnOffset ]);
 
-									for ( var i = 1; i <= line.length; i += 1 ) {
+									for ( let i = 1; i <= line.length; i += 1 ) {
 										encodedLine += ',CAAC'; // equivalent to encode([ 1, 0, 0, 1 ])
 									}
 
@@ -104,12 +104,12 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 		}
 
 		function writeResult () {
-			var code = fileContents.join( options.separator || '\n\n' );
+			let code = fileContents.join( options.separator || '\n\n' );
 
 			if ( shouldCreateSourcemap ) {
-				var comment = getSourcemapComment[ ext ]( basename( options.dest ) );
+				const comment = getSourcemapComment[ ext ]( basename( options.dest ) );
 
-				code += "\n" + comment;
+				code += `\n${comment}`;
 
 				return sander.Promise.all([
 					sander.writeFile( outputdir, options.dest, code ),

--- a/src/index.js
+++ b/src/index.js
@@ -23,15 +23,13 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 		let alreadySeen = {};
 		let fileContents = [];
 
-		if ( shouldCreateSourcemap ) {
-			let sourceMap = {
-				version: 3,
-				file: basename( options.dest ),
-				sources: [],
-				sourcesContent: [],
-				mappings: ''
-			};
-		}
+		let sourceMap = shouldCreateSourcemap ? {
+			version: 3,
+			file: basename( options.dest ),
+			sources: [],
+			sourcesContent: [],
+			mappings: ''
+		} : null;
 
 		if ( !patterns ) {
 			// use all files
@@ -66,6 +64,7 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 						sourceMap.sources.push( join( inputdir, filename ) );
 						sourceMap.sourcesContent.push( contents );
 
+						contents = contents.replace( /^(?:\/\/[@#]\s*sourceMappingURL=(\S+)|\/\*#?\s*sourceMappingURL=(\S+)\s?\*\/)$/gm, '' );
 						const lines = contents.split( '\n' );
 
 						const encoded = lines

--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,12 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 	const separatorSemis = separator.split( '\n' ).join( ';' )
 
 	return sander.lsr( inputdir ).then( allFiles => {
-		var patterns = options.files;
-		var alreadySeen = {};
-		var fileContents = [];
+		let patterns = options.files;
+		let alreadySeen = {};
+		let fileContents = [];
 
 		if ( shouldCreateSourcemap ) {
-			var sourceMap = {
+			let sourceMap = {
 				version: 3,
 				file: basename( options.dest ),
 				sources: [],
@@ -42,9 +42,9 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 			patterns = [ patterns ];
 		}
 
-		return mapSeries( patterns, function ( pattern ) {
-			var filtered = allFiles.filter( function ( filename ) {
-				var shouldInclude = !alreadySeen[ filename ] && minimatch( filename, pattern );
+		return mapSeries( patterns, pattern => {
+			let filtered = allFiles.filter( filename => {
+				const shouldInclude = !alreadySeen[ filename ] && minimatch( filename, pattern );
 
 				if ( shouldInclude ) alreadySeen[ filename ] = true;
 				return shouldInclude;
@@ -104,7 +104,7 @@ module.exports = function concat ( inputdir, outputdir, options ) {
 		}
 
 		function writeResult () {
-			let code = fileContents.join( options.separator || '\n\n' );
+			let code = fileContents.join( separator );
 
 			if ( shouldCreateSourcemap ) {
 				const comment = getSourcemapComment[ ext ]( basename( options.dest ) );

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,10 @@ describe( 'gobble-concat', () => {
 
 						if ( extname( file ) === '.map' ) {
 							contents = JSON.parse( contents );
+
+							if ( contents.sources ) {
+								contents.sources = contents.sources.map( source => resolve( dir, x, source ) );
+							}
 						}
 
 						return { file, contents };

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,44 @@
+const assert = require( 'assert' );
+const { resolve } = require( 'path' );
+const { lsrSync, mkdir, mkdirSync, readdirSync, readFileSync, rimraf } = require( 'sander' );
+const { describe, it, afterEach } = require( 'mocha' );
+const glob = require( 'glob' );
+const concat = require( '..' );
+
+const TMP = resolve( __dirname, 'tmp' );
+
+describe( 'gobble-concat', () => {
+	const TESTS = resolve( __dirname, 'tests' );
+
+	readdirSync( TESTS ).forEach( dir => {
+		if ( dir[0] === '.' ) return;
+
+		const input = resolve( TESTS, dir, 'input' );
+		const expected = resolve( TESTS, dir, 'expected' );
+		const output = resolve( TESTS, dir, 'output' );
+
+		it( dir, () => {
+			const options = require( resolve( TESTS, dir, 'options.js' ) );
+
+			mkdirSync( output );
+
+			function catalogue ( x ) {
+				return glob.sync( '**', { cwd: x })
+					.map( file => {
+						return {
+							file,
+							contents: readFileSync( TESTS, dir, x, file, { encoding: 'utf-8' })
+						};
+					});
+			}
+
+			return concat( input, output, options )
+				.then( () => {
+					assert.deepEqual(
+						catalogue( output ),
+						catalogue( expected )
+					);
+				});
+		});
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const assert = require( 'assert' );
-const { resolve } = require( 'path' );
+const { extname, resolve } = require( 'path' );
 const { lsrSync, mkdir, mkdirSync, readdirSync, readFileSync, rimraf } = require( 'sander' );
 const { describe, it, afterEach } = require( 'mocha' );
 const glob = require( 'glob' );
@@ -25,10 +25,13 @@ describe( 'gobble-concat', () => {
 			function catalogue ( x ) {
 				return glob.sync( '**', { cwd: x })
 					.map( file => {
-						return {
-							file,
-							contents: readFileSync( TESTS, dir, x, file, { encoding: 'utf-8' })
-						};
+						let contents = readFileSync( TESTS, dir, x, file, { encoding: 'utf-8' }).trim();
+
+						if ( extname( file ) === '.map' ) {
+							contents = JSON.parse( contents );
+						}
+
+						return { file, contents };
 					});
 			}
 

--- a/test/tests/concatenates-all-files-alphabetically/expected/bundle.js
+++ b/test/tests/concatenates-all-files-alphabetically/expected/bundle.js
@@ -1,0 +1,4 @@
+console.log( 'bar' );
+
+
+console.log( 'foo' );

--- a/test/tests/concatenates-all-files-alphabetically/input/bar.js
+++ b/test/tests/concatenates-all-files-alphabetically/input/bar.js
@@ -1,0 +1,1 @@
+console.log( 'bar' );

--- a/test/tests/concatenates-all-files-alphabetically/input/foo.js
+++ b/test/tests/concatenates-all-files-alphabetically/input/foo.js
@@ -1,0 +1,1 @@
+console.log( 'foo' );

--- a/test/tests/concatenates-all-files-alphabetically/options.js
+++ b/test/tests/concatenates-all-files-alphabetically/options.js
@@ -1,0 +1,3 @@
+module.exports = {
+	dest: 'bundle.js'
+};

--- a/test/tests/concatenates-all-files-alphabetically/options.js
+++ b/test/tests/concatenates-all-files-alphabetically/options.js
@@ -1,3 +1,4 @@
 module.exports = {
-	dest: 'bundle.js'
+	dest: 'bundle.js',
+	sourceMap: false
 };

--- a/test/tests/concatenates-files-in-specified-order/expected/bundle.js
+++ b/test/tests/concatenates-files-in-specified-order/expected/bundle.js
@@ -1,0 +1,4 @@
+console.log( 'foo' );
+
+
+console.log( 'bar' );

--- a/test/tests/concatenates-files-in-specified-order/input/bar.js
+++ b/test/tests/concatenates-files-in-specified-order/input/bar.js
@@ -1,0 +1,1 @@
+console.log( 'bar' );

--- a/test/tests/concatenates-files-in-specified-order/input/foo.js
+++ b/test/tests/concatenates-files-in-specified-order/input/foo.js
@@ -1,0 +1,1 @@
+console.log( 'foo' );

--- a/test/tests/concatenates-files-in-specified-order/options.js
+++ b/test/tests/concatenates-files-in-specified-order/options.js
@@ -1,0 +1,4 @@
+module.exports = {
+	files: [ 'foo.js', 'bar.js' ],
+	dest: 'bundle.js'
+};

--- a/test/tests/concatenates-files-in-specified-order/options.js
+++ b/test/tests/concatenates-files-in-specified-order/options.js
@@ -1,4 +1,5 @@
 module.exports = {
 	files: [ 'foo.js', 'bar.js' ],
-	dest: 'bundle.js'
+	dest: 'bundle.js',
+	sourceMap: false
 };

--- a/test/tests/creates-sourcemap-for-js/expected/bundle.js
+++ b/test/tests/creates-sourcemap-for-js/expected/bundle.js
@@ -1,0 +1,9 @@
+console.log( 'bar' );
+
+
+console.log( 'baz' );
+
+
+console.log( 'foo' );
+
+//# sourceMappingURL=bundle.js.map

--- a/test/tests/creates-sourcemap-for-js/expected/bundle.js.map
+++ b/test/tests/creates-sourcemap-for-js/expected/bundle.js.map
@@ -2,9 +2,9 @@
   "version": 3,
   "file": "bundle.js",
   "sources": [
-    "/Volumes/Storage/www/GOBBLE/plugins/gobble-concat/test/tests/creates-sourcemap-for-js/input/bar.js",
-    "/Volumes/Storage/www/GOBBLE/plugins/gobble-concat/test/tests/creates-sourcemap-for-js/input/baz.js",
-    "/Volumes/Storage/www/GOBBLE/plugins/gobble-concat/test/tests/creates-sourcemap-for-js/input/foo.js"
+    "../input/bar.js",
+    "../input/baz.js",
+    "../input/foo.js"
   ],
   "sourcesContent": [
     "console.log( 'bar' );\n",

--- a/test/tests/creates-sourcemap-for-js/expected/bundle.js.map
+++ b/test/tests/creates-sourcemap-for-js/expected/bundle.js.map
@@ -1,0 +1,15 @@
+{
+  "version": 3,
+  "file": "bundle.js",
+  "sources": [
+    "/Volumes/Storage/www/GOBBLE/plugins/gobble-concat/test/tests/creates-sourcemap-for-js/input/bar.js",
+    "/Volumes/Storage/www/GOBBLE/plugins/gobble-concat/test/tests/creates-sourcemap-for-js/input/baz.js",
+    "/Volumes/Storage/www/GOBBLE/plugins/gobble-concat/test/tests/creates-sourcemap-for-js/input/foo.js"
+  ],
+  "sourcesContent": [
+    "console.log( 'bar' );\n",
+    "console.log( 'baz' );\n",
+    "console.log( 'foo' );\n"
+  ],
+  "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;;;ACDrB,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;;;ACDrB,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;;;"
+}

--- a/test/tests/creates-sourcemap-for-js/input/bar.js
+++ b/test/tests/creates-sourcemap-for-js/input/bar.js
@@ -1,0 +1,1 @@
+console.log( 'bar' );

--- a/test/tests/creates-sourcemap-for-js/input/baz.js
+++ b/test/tests/creates-sourcemap-for-js/input/baz.js
@@ -1,0 +1,1 @@
+console.log( 'baz' );

--- a/test/tests/creates-sourcemap-for-js/input/foo.js
+++ b/test/tests/creates-sourcemap-for-js/input/foo.js
@@ -1,0 +1,1 @@
+console.log( 'foo' );

--- a/test/tests/creates-sourcemap-for-js/options.js
+++ b/test/tests/creates-sourcemap-for-js/options.js
@@ -1,0 +1,3 @@
+module.exports = {
+	dest: 'bundle.js'
+};

--- a/test/tests/removes-existing-sourcemap-comments/expected/bundle.js
+++ b/test/tests/removes-existing-sourcemap-comments/expected/bundle.js
@@ -1,0 +1,12 @@
+console.log( 'bar' );
+
+
+
+console.log( 'baz' );
+
+
+
+console.log( 'foo' );
+
+
+//# sourceMappingURL=bundle.js.map

--- a/test/tests/removes-existing-sourcemap-comments/expected/bundle.js.map
+++ b/test/tests/removes-existing-sourcemap-comments/expected/bundle.js.map
@@ -1,0 +1,15 @@
+{
+  "version": 3,
+  "file": "bundle.js",
+  "sources": [
+    "../input/bar.js",
+    "../input/baz.js",
+    "../input/foo.js"
+  ],
+  "sourcesContent": [
+    "console.log( 'bar' );\n//# sourceMappingURL=one.js.map\n",
+    "console.log( 'baz' );\n//# sourceMappingURL=two.js.map\n",
+    "console.log( 'foo' );\n//# sourceMappingURL=three.js.map\n"
+  ],
+  "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;;;;ACDrB,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;;;;ACDrB,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;;;;"
+}

--- a/test/tests/removes-existing-sourcemap-comments/input/bar.js
+++ b/test/tests/removes-existing-sourcemap-comments/input/bar.js
@@ -1,0 +1,2 @@
+console.log( 'bar' );
+//# sourceMappingURL=one.js.map

--- a/test/tests/removes-existing-sourcemap-comments/input/baz.js
+++ b/test/tests/removes-existing-sourcemap-comments/input/baz.js
@@ -1,0 +1,2 @@
+console.log( 'baz' );
+//# sourceMappingURL=two.js.map

--- a/test/tests/removes-existing-sourcemap-comments/input/foo.js
+++ b/test/tests/removes-existing-sourcemap-comments/input/foo.js
@@ -1,0 +1,2 @@
+console.log( 'foo' );
+//# sourceMappingURL=three.js.map

--- a/test/tests/removes-existing-sourcemap-comments/options.js
+++ b/test/tests/removes-existing-sourcemap-comments/options.js
@@ -1,0 +1,3 @@
+module.exports = {
+	dest: 'bundle.js'
+};


### PR DESCRIPTION
@IvanSanchez I started looking into https://github.com/Rich-Harris/sorcery/issues/68 and ended up in a bit of a rabbit hole – bear with me:

AFAICT, as of https://github.com/gobblejs/gobble-concat/pull/1 gobble-concat processes the sourcemaps of its sources – is that right? When I tried to build Leaflet.VectorGrid, it fell apart because one of the sources had an inline data URI for the sourceMappingURL, which wasn't expected.

Anyway, processing incoming sourcemaps is a bit unusual – in theory a transformer should only worry about creating a sourcemap for its own transformation, and let Gobble flatten everything as a final step. To that end, this PR reverts 1aaa1f68c0a4f83fff6417ac681f670861cf4af9 and generates fresh sourcemaps for all `.js` and `.css` files (unless `options.sourceMap === false`), ignoring existing sourcemaps other than to remove the `sourceMappingURL` comments.

It does a couple of other things besides (I should have been a bit more disciplined and done this as several PRs, but like I said, rabbit hole...) – it adds some tests and a build process.

What do you reckon?
