### PR TITLE
Fixed bug where end comment would be included in source map url

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var sander = require( 'sander' ),
 var SourceNode = require( 'source-map' ).SourceNode;
 var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
 
-var sourceMapRegExp = new RegExp(/(?:\/\/#|\/\/@|\/\*#)\s*sourceMappingURL=(.*)\s*(?:\*\/\s*)?$/);
+var sourceMapRegExp = new RegExp(/(?:\/\/#|\/\/@|\/\*#)\s*sourceMappingURL=(.*?)\s*(?:\*\/\s*)?$/);
 var extensionsRegExp = new RegExp(/(\.js|\.css)$/);
 
 module.exports = function concat ( inputdir, outputdir, options ) {


### PR DESCRIPTION
Previously, with a sourcemap string such as

```
/*# sourceMappingURL=styles.css.map */
```

the first capturing group would be

```
styles.css.map */
```

Changing to first capturing group to be lazy fixes this.
